### PR TITLE
Try reusing RAPT when refreshing access token.

### DIFF
--- a/google_reauth/reauth_creds.py
+++ b/google_reauth/reauth_creds.py
@@ -85,6 +85,46 @@ class Oauth2WithReauthCredentials(client.OAuth2Credentials):
         json = original.to_json()
         return cls.from_json(json)
 
+    def _refresh(self, http):
+        """Refreshes the access_token.
+
+        This method first checks by reading the Storage object if available.
+        If a refresh is still needed, it holds the Storage lock until the
+        refresh is completed.
+
+        Args:
+            http: an object to be used to make HTTP requests.
+
+        Raises:
+            HttpAccessTokenRefreshError: When the refresh fails.
+        """
+        if not self.store:
+            self._do_refresh_request(http)
+        else:
+            self.store.acquire_lock()
+            try:
+                new_cred = self.store.locked_get()
+
+                if (new_cred and not new_cred.invalid and
+                        new_cred.access_token != self.access_token and
+                        not new_cred.access_token_expired):
+                    _LOGGER.info('Updated access_token read from Storage')
+                    self._updateFromCredential(new_cred)
+                else:
+                    if (new_cred and not new_cred.invalid and
+                            getattr(new_cred, 'rapt_token', None)):
+                        # If the access token has expired, the RAPT may not have
+                        # expired yet. Try to refresh with the RAPT first, which
+                        # only forces users to answer reauth challenges if the
+                        # RAPT has expired, as opposed to every time the access
+                        # token expires.
+                        _LOGGER.info('Could not use access token from Storage, '
+                                     'but still reusing the rapt_token.')
+                        self.rapt_token = new_cred.rapt_token
+                    self._do_refresh_request(http)
+            finally:
+                self.store.release_lock()
+
     def _do_refresh_request(self, http):
         """Refresh the access_token using the refresh_token.
 


### PR DESCRIPTION
If an access token has expired, the RAPT may not have expired yet.
Rather than force users to answer a reauth challenge every time their
access token expires, we should try reusing the cached RAPT - worst case
scenario, the request comes back as a 400 and the library silently
fetches a new RAPT (as it was already doing).