### PR TITLE
Add SAML challenge as a supported type for reauth flow.

### DIFF
--- a/google_reauth/challenges.py
+++ b/google_reauth/challenges.py
@@ -123,10 +123,31 @@ class SecurityKeyChallenge(ReauthChallenge):
         return None
 
 
+class SamlChallenge(ReauthChallenge):
+    """Challenge that asks SAML users to complete SAML login."""
+
+    @property
+    def name(self):
+        return 'SAML'
+
+    @property
+    def is_locally_eligible(self):
+        return True
+
+    def obtain_challenge_input(self, metadata):
+        # Magic Arch has not fully supported returning a proper dedirect URL
+        # for programmatic SAML users today. So we error our here and request
+        # users to complete a web login.
+        sys.stderr.write('SAML login is required for the current account to '
+                         'complete reauthentication.')
+        return None
+
+
 AVAILABLE_CHALLENGES = {
     challenge.name: challenge
     for challenge in [
         SecurityKeyChallenge(),
-        PasswordChallenge()
+        PasswordChallenge(),
+        SamlChallenge()
     ]
 }

--- a/google_reauth/reauth.py
+++ b/google_reauth/reauth.py
@@ -82,10 +82,10 @@ def _run_next_challenge(msg, http_request, access_token):
                 challenge['challengeType'], None)
         if not c:
             raise errors.ReauthFailError(
-                'Unsupported challenge type {0}. Supported types: {0}'
-                .format(
-                    challenge['challengeType'],
-                    ','.join(list(challenges.AVAILABLE_CHALLENGES.keys()))))
+                'Unsupported challenge type {0}. Supported types: {1}'
+                .format(challenge['challengeType'],
+                        ','.join(list(challenges.AVAILABLE_CHALLENGES.keys())))
+            )
         if not c.is_locally_eligible:
             raise errors.ReauthFailError(
                 'Challenge {0} is not locally eligible'

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -78,3 +78,13 @@ class ChallengesTest(unittest.TestCase):
     def testNoPassword(self, getpass_mock):
         self.assertEqual(challenges.PasswordChallenge().obtain_challenge_input({}),
             {'credential': ' '})
+
+    def testSaml(self):
+        metadata = {
+            'status': 'READY',
+            'challengeId': 1,
+            'challengeType': 'SAML',
+            'securityKey': {}
+            }
+        challenge = challenges.SamlChallenge()
+        self.assertEqual(None, challenge.obtain_challenge_input(metadata))


### PR DESCRIPTION
Currently SAML challenge will error out and encourage user to do a gcloud auth login and allow user to be authenticated through their IDP.