### PR TITLE
Raise an exception in `SamlChallenge`.

### DIFF
--- a/google_reauth/challenges.py
+++ b/google_reauth/challenges.py
@@ -21,7 +21,7 @@ import pyu2f.errors
 import pyu2f.model
 import six
 
-from google_reauth import _helpers
+from google_reauth import _helpers, errors
 
 
 REAUTH_ORIGIN = 'https://accounts.google.com'
@@ -124,7 +124,7 @@ class SecurityKeyChallenge(ReauthChallenge):
 
 
 class SamlChallenge(ReauthChallenge):
-    """Challenge that asks SAML users to complete SAML login."""
+    """Challenge that asks the users to browse to their ID Providers."""
 
     @property
     def name(self):
@@ -138,9 +138,7 @@ class SamlChallenge(ReauthChallenge):
         # Magic Arch has not fully supported returning a proper dedirect URL
         # for programmatic SAML users today. So we error our here and request
         # users to complete a web login.
-        sys.stderr.write('SAML login is required for the current account to '
-                         'complete reauthentication.')
-        return None
+        raise errors.ReauthSamlLoginRequiredError()
 
 
 AVAILABLE_CHALLENGES = {

--- a/google_reauth/errors.py
+++ b/google_reauth/errors.py
@@ -60,3 +60,16 @@ class ReauthAccessTokenRefreshError(ReauthError):
             'Failed to get an access token for reauthentication. {0}'.format(
                 message))
         self.status = status
+
+
+class ReauthSamlLoginRequiredError(ReauthError):
+    """An exception for when web login is required to complete reauth.
+
+    This applies to SAML users who are required to login through their IDP to
+    complete reauth.
+    """
+
+    def __init__(self):
+        super(ReauthSamlLoginRequiredError, self).__init__(
+            'SAML login is required for the current account to complete '
+            'reauthentication.')

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -21,7 +21,7 @@ import unittest
 
 import mock
 
-from google_reauth import challenges
+from google_reauth import challenges, errors
 
 import pyu2f
 
@@ -87,4 +87,6 @@ class ChallengesTest(unittest.TestCase):
             'securityKey': {}
             }
         challenge = challenges.SamlChallenge()
-        self.assertEqual(None, challenge.obtain_challenge_input(metadata))
+        self.assertEqual(True, challenge.is_locally_eligible)
+        with self.assertRaises(errors.ReauthSamlLoginRequiredError):
+            challenge.obtain_challenge_input(metadata)


### PR DESCRIPTION
This challenge should raise an exception. It should be bubbled up
to the app (such as gcloud or gsutil) to display informative messages
so that the users can complete re-authentication properly (e.g. by
running `gcloud auth login` or `gsutil config` again).